### PR TITLE
geofence - fix GF incompatibility with GWC

### DIFF
--- a/geofence/geofence-server.properties
+++ b/geofence/geofence-server.properties
@@ -1,0 +1,1 @@
+gwc.context.suffix=gwc


### PR DESCRIPTION
When geofence is activated and available in the webapp, it can misbehave with the different endpoints, e.g. hitting /geoserver/ redirects onto the integrated GWC webapp instead of /geoserver/web/.

Reported upstream here: https://github.com/geoserver/geofence/issues/102

Tests: runtime on the GGE env.
Note: it might require a redeploy to get it actually working.
