### PR TITLE
datadir aligned with geoserver 2.15.x on master

### DIFF
--- a/global.xml
+++ b/global.xml
@@ -5,7 +5,7 @@
     <charset>UTF-8</charset>
     <numDecimals>6</numDecimals>
     <onlineResource>http://geoserver.org</onlineResource>
-    <proxyBaseUrl>https://georchestra.mydomain.org/geoserver</proxyBaseUrl>
+    <proxyBaseUrl>${X-Forwarded-Proto}://${X-Forwarded-Host}/geoserver</proxyBaseUrl>
     <verbose>false</verbose>
     <verboseExceptions>false</verboseExceptions>
     <metadata>
@@ -31,6 +31,32 @@
     <allowNativeMosaic>false</allowNativeMosaic>
     <allowNativeWarp>false</allowNativeWarp>
     <pngEncoderType>PNGJ</pngEncoderType>
+    <jaiext>
+      <jaiExtOperations class="sorted-set">
+        <string>Affine</string>
+        <string>BandCombine</string>
+        <string>BandMerge</string>
+        <string>BandSelect</string>
+        <string>Binarize</string>
+        <string>Border</string>
+        <string>ColorConvert</string>
+        <string>Crop</string>
+        <string>ErrorDiffusion</string>
+        <string>Format</string>
+        <string>ImageFunction</string>
+        <string>Lookup</string>
+        <string>Mosaic</string>
+        <string>Null</string>
+        <string>OrderedDither</string>
+        <string>Rescale</string>
+        <string>Scale</string>
+        <string>Stats</string>
+        <string>Translate</string>
+        <string>Warp</string>
+        <string>algebric</string>
+        <string>operationConst</string>
+      </jaiExtOperations>
+    </jaiext>
   </jai>
   <coverageAccess>
     <maxPoolSize>10</maxPoolSize>
@@ -42,7 +68,9 @@
   <updateSequence>0</updateSequence>
   <featureTypeCacheSize>0</featureTypeCacheSize>
   <globalServices>true</globalServices>
+  <useHeadersProxyURL>true</useHeadersProxyURL>
   <xmlPostRequestLogBufferSize>1024</xmlPostRequestLogBufferSize>
   <xmlExternalEntitiesEnabled>false</xmlExternalEntitiesEnabled>
+  <webUIMode>DEFAULT</webUIMode>
   <resourceErrorHandling>SKIP_MISCONFIGURED_LAYERS</resourceErrorHandling>
 </global>

--- a/security/filter/exception/config.xml
+++ b/security/filter/exception/config.xml
@@ -2,5 +2,4 @@
   <id>-e3457ae:13cce0c47c6:-7ff2</id>
   <name>exception</name>
   <className>org.geoserver.security.filter.GeoServerExceptionTranslationFilter</className>
-  <accessDeniedErrorPage>/accessDenied.jsp</accessDeniedErrorPage>
 </exceptionTranslation>


### PR DESCRIPTION
Now that we have 2.15 on master, we can take advantage of https://docs.geoserver.org/stable/en/user/configuration/globalsettings.html#use-headers-for-proxy-url to have dynamic capabilities url (eg: `http` if user requests the `http` service, `https` if the user requests the `https` service)

The drawback being the following:
```
curl -u testadmin:testadmin -k -s -H 'X-Forwarded-Host: truite' 'https://georchestra.mydomain.org/geoserver/wms?service=wms&request=getcapabilities' | grep OnlineResource
<OnlineResource xlink:type="simple" xlink:href="https://truite/geoserver/ows?SERVICE=WMS&amp;"/>
```
Which means we have to clean incoming X-Forwarded-* headers (hence on traefik for georchestra/docker)