### PR TITLE
UTF-8 as character encoding for SLDs

### DIFF
--- a/styles/raster.sld
+++ b/styles/raster.sld
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<StyledLayerDescriptor version="1.0.0" 
- xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
- xmlns="http://www.opengis.net/sld" 
- xmlns:ogc="http://www.opengis.net/ogc" 
- xmlns:xlink="http://www.w3.org/1999/xlink" 
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0"
+ xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+ xmlns="http://www.opengis.net/sld"
+ xmlns:ogc="http://www.opengis.net/ogc"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <!-- a Named Layer is the basic building block of an SLD document -->
   <NamedLayer>

--- a/www/styles/green.sld
+++ b/www/styles/green.sld
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <StyledLayerDescriptor version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 <!-- a named layer is the basic building block of an sld document -->
 <NamedLayer>
@@ -17,13 +17,12 @@
          <Fill>
             <!-- CssParameters allowed are fill (the color) and fill-opacity -->
             <CssParameter name="fill">#66FF66</CssParameter>
-         </Fill>   
+         </Fill>
             <Stroke/>
-                
+
         </PolygonSymbolizer>
       </Rule>
     </FeatureTypeStyle>
 </UserStyle>
 </NamedLayer>
 </StyledLayerDescriptor>
-

--- a/www/styles/remoteOws.sld
+++ b/www/styles/remoteOws.sld
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <StyledLayerDescriptor version="1.0.0" xmlns="http://www.opengis.net/sld"
   xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/www/styles/remoteTasmania.sld
+++ b/www/styles/remoteTasmania.sld
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <StyledLayerDescriptor version="1.0.0" xmlns="http://www.opengis.net/sld"
   xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
This is the following of the previous incomplete PR11, generalizing
switch to UTF-8 for all styles.

Having the styles in ISO messes up things when an user edits them via
the UI editor from GS (as the UI is supposed to be full utf-8,
everything posted will be interpreted as UTF-8, not ISO, messing up the
charset).

Switching to UTF-8 is not an issue here because we don't have any 
accented chars in the files anyway.

Note: if we git grep onto 'ISO-8859' in the repository, there are still
some references, but on automated_tests layer ; a shapefile is provided
where the attributes are still encoded in this charset.