### PR TITLE
feat: adding default controlflow priority property

### DIFF
--- a/controlflow.properties
+++ b/controlflow.properties
@@ -22,3 +22,5 @@ user=10
 # (assuming a server with 2 cores, GWC empirical tests show that throughput
 # peaks up at 4 x number of cores. Adjust as appropriate to your system)
 ows.gwc=8
+
+ows.priority.http=ctrl-flow-priority,0


### PR DESCRIPTION
Allow requests having a specific header to by-pass the queue introduced by the control-flow extension.
This is particularly handy for eg healthchecks.

More documentation: https://docs.geoserver.org/main/en/user/extensions/controlflow/index.html#request-priority-support

Needs to be ported to the 24.0 branch too.